### PR TITLE
Add a menu tab to admin/content

### DIFF
--- a/views/queues.views.inc
+++ b/views/queues.views.inc
@@ -164,6 +164,11 @@ function queues_views_default_views() {
   /* Display: Page */
   $handler = $view->new_display('page', 'Page', 'page');
   $handler->display->display_options['path'] = 'admin/content/queues';
+  $handler->display->display_options['menu']['type'] = 'tab';
+  $handler->display->display_options['menu']['title'] = 'Queues';
+  $handler->display->display_options['menu']['weight'] = '0';
+  $handler->display->display_options['menu']['context'] = 0;
+  $handler->display->display_options['menu']['context_only_inline'] = 0;
   $views['queues_listing'] = $view;
 
   return $views;


### PR DESCRIPTION
I just found this module, at first glance there does not seem to be a way to access the queues without typing the path directly.  I've updated the view to provide a menu tab to access the queues without typing the path directly to the content list.

![queues listing site-install](https://f.cloud.github.com/assets/810903/2378583/642f67e6-a890-11e3-8b98-ef033fe89b69.jpg)
