### PR TITLE
Fix soft dependency

### DIFF
--- a/views/handlers/views_handler_field_queue_link.inc
+++ b/views/handlers/views_handler_field_queue_link.inc
@@ -44,10 +44,4 @@ class queues_views_handler_field_queue_operations extends queues_views_handler_f
 
     return $output;
   }
-
-  function add_ctools_css() {
-    parent::add_ctools_css();
-    // Include the dropbutton css from pub_editorial.
-    drupal_add_css(drupal_get_path('module', 'pub_editorial') . '/css/pub_editorial.css', array('weight' => 10));
-  }
 }

--- a/views/handlers/views_handler_field_queue_link.inc
+++ b/views/handlers/views_handler_field_queue_link.inc
@@ -36,6 +36,7 @@ class queues_views_handler_field_queue_operations extends queues_views_handler_f
         );
       }
 
+      drupal_alter('queues_views_handler_field_queue_operations', $links);
       $output = theme('links__ctools_dropbutton', array('title' => t('operations'), 'links' => $links));
     }
 

--- a/views/handlers/views_handler_field_queue_publish.inc
+++ b/views/handlers/views_handler_field_queue_publish.inc
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Definition of queues_views_handler_field_operations.
+ * Definition of queues_views_handler_publish_state.
  */
 
 /**
@@ -26,10 +26,10 @@ class queues_views_handler_publish_state extends views_handler_field {
     $output = '';
     $status = $this->get_value($values, 'queues_status');
     if ($status == 1) {
-	  $output = t('Published');
+	    $output = t('Published');
     }
     else {
-	  $output = t('Unpublished');
+	    $output = t('Unpublished');
     }
 
     return $output;

--- a/views/handlers/views_handler_field_queues_revision_link.inc
+++ b/views/handlers/views_handler_field_queues_revision_link.inc
@@ -50,9 +50,10 @@ class queues_views_handler_field_operations extends views_handler_field {
           'query' => array('edit[revision_id]' => $this->get_value($values, 'vid')),
         );
       }
+
+      drupal_alter('queues_views_handler_field_operations', $links);
       $output = theme('links__ctools_dropbutton', array('title' => t('operations'), 'links' => $links));
     }
-    drupal_alter('queues_views_handler_field_operations', $links);
 
     $this->add_ctools_css();
 


### PR DESCRIPTION
Fixes #9

That unrelated module, whoever runs that thing… can now move from a blatant hack, to something really complicated and completely un-The Drupal Way :tm:

``` php
/**
 * Implements hook_queues_views_handler_field_queue_operations_alter().
 */
function pub_editorial_queues_views_handler_field_queue_operations_alter ($links) {
  // Include the dropbutton css from pub_editorial.
  drupal_add_css(drupal_get_path('module', 'pub_editorial') . '/css/pub_editorial.css', array('weight' => 10));
}
```
